### PR TITLE
Update URL to JAX-RS API 2.1.6 Javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
                 <version>3.3.1</version>
                 <configuration>
                     <links combine.self="override">
-                        <link>https://eclipse-ee4j.github.io/jaxrs-api/apidocs/2.1.6/</link>
+                        <link>https://jakartaee.github.io/rest/apidocs/2.1.6/</link>
                         <link>https://javaee.github.io/hk2/apidocs/</link>
                     </links>
                 </configuration>


### PR DESCRIPTION
The Javadoc publication moved from https://eclipse-ee4j.github.io/jaxrs-api/apidocs/2.1.6/ to 
https://jakartaee.github.io/rest/apidocs/2.1.6/.

```text
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.3.1:javadoc (default-cli) on project jersey-container-jetty-http: An error has occurred in Javadoc report generation:
[ERROR] Exit code: 1 - javadoc: error - Error fetching URL: https://eclipse-ee4j.github.io/jaxrs-api/apidocs/2.1.6/
[ERROR]
[ERROR] Command line was: /path/to/jdk/bin/javadoc -J-Xmx256m @options @argfile
[ERROR]
[ERROR] Refer to the generated Javadoc files in '/path/to/jersey-container-jetty-http/target/site/apidocs' dir.
```